### PR TITLE
Fix overflow hidden property on Android

### DIFF
--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -3,8 +3,8 @@ import { TouchableOpacity, Text } from "react-native";
 
 import styles from "./styles";
 
-const Box = ({ content, style, onPress }) => (
-  <TouchableOpacity style={style} activeOpacity={0.8} onPress={onPress}>
+const Box = ({ content, style, onPress, onLayout }) => (
+  <TouchableOpacity style={style} activeOpacity={0.8} onPress={onPress} onLayout={onLayout ? onLayout : null}>
     <Text style={styles.text}>{content}</Text>
   </TouchableOpacity>
 );

--- a/src/components/Controls/Controls.js
+++ b/src/components/Controls/Controls.js
@@ -5,9 +5,14 @@ import { Box } from "../Box/";
 import styles from "./styles";
 
 const Controls = props => (
-  <View style={styles.controls} onLayout={props.onLayout}>
-    <View style={[styles.row, { position: "absolute", top: props.top }]}>
+  <View style={styles.controls} onLayout={props.measureControls}>
+    <View style={[styles.pretender, {
+      height: (props.boxHeight / 2) + props.controlsPadding,
+    }]} />
+
+    <View style={styles.row}>
       <Box
+        onLayout={props.measureBox}
         style={[styles.box, styles.green]}
         content="AC"
         onPress={props.clearResult}
@@ -28,7 +33,7 @@ const Controls = props => (
         onPress={() => props.saveExpression("/")}
       />
     </View>
-    <View style={[styles.row, styles.second]}>
+    <View style={styles.row}>
       <Box
         style={[styles.box, styles.black]}
         content="7"
@@ -50,7 +55,7 @@ const Controls = props => (
         onPress={() => props.saveExpression("*")}
       />
     </View>
-    <View style={[styles.row, styles.third]}>
+    <View style={styles.row}>
       <Box
         style={[styles.box, styles.black]}
         content="4"
@@ -72,7 +77,7 @@ const Controls = props => (
         onPress={() => props.saveExpression("-")}
       />
     </View>
-    <View style={[styles.row, styles.fourth]}>
+    <View style={styles.row}>
       <Box
         style={[styles.box, styles.black]}
         content="1"
@@ -94,7 +99,7 @@ const Controls = props => (
         onPress={() => props.saveExpression("+")}
       />
     </View>
-    <View style={[styles.row, styles.fifth]}>
+    <View style={styles.row}>
       <Box
         style={[styles.box, styles.double, styles.black]}
         content="0"

--- a/src/components/Controls/styles.js
+++ b/src/components/Controls/styles.js
@@ -3,19 +3,22 @@ import { StyleSheet } from "react-native";
 const styles = StyleSheet.create({
   controls: {
     flex: 1,
-    backgroundColor: "#333E52"
+    backgroundColor: "#333E52",
+    padding: "1%"
   },
+  pretender: {
+    backgroundColor: "#3CB6EE",
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+},
   row: {
     flex: 1,
     flexDirection: "row",
     flexWrap: "wrap",
-    position: "relative"
+    position: "relative",
   },
-  first: { top: -25 },
-  second: { top: -20 },
-  third: { top: -15 },
-  fourth: { top: -10 },
-  fifth: { top: -5 },
   box: {
     justifyContent: "center",
     alignItems: "center",

--- a/src/components/Result/styles.js
+++ b/src/components/Result/styles.js
@@ -3,7 +3,6 @@ import { StyleSheet, Platform } from "react-native";
 const styles = StyleSheet.create({
   result: {
     color: "white",
-    backgroundColor: "yellow",
     fontSize: 72,
     fontWeight: "300",
     padding: Platform.OS === "ios" ? 50 : 4,

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -11,10 +11,22 @@ import styles from "./styles";
 class App extends Component {
   constructor(props) {
     super(props);
-    this.state = { top: 0 };
+    this.state = {
+        boxHeight: 0,
+        controlsPadding: 0,
+    };
   }
 
-  _onLayout = ({ nativeEvent: { layout: { y } } }) => this.setState({ top: y });
+  measureControls = (e) => {
+      const { height } = e.nativeEvent.layout;
+      const padding = height * 0.01; // 1% of height
+      this.setState({ controlsPadding: padding });
+  }
+
+  measureBox = (e) => {
+      const { height } = e.nativeEvent.layout;
+      this.setState({ boxHeight: height });
+  }
 
   render() {
     return (
@@ -25,8 +37,10 @@ class App extends Component {
           <Result content={this.props.result} />
           <Controls
             {...this.props}
-            onLayout={this._onLayout}
-            top={this.state.top}
+            measureControls={this.measureControls}
+            controlsPadding={this.state.controlsPadding}
+            measureBox={this.measureBox}
+            boxHeight={this.state.boxHeight}
           />
         </View>
       </View>


### PR DESCRIPTION
This fixes the `overflow: hidden` property on android.

It works by changing the buttons to not overflow, but adds a `View` component to the controls underneath the buttons, the same colour as the `Result` component  so it looks the same.

There's an onLayout added to both the `Box` components (only needed on one though) and on the root `View` in `Controls`. The pretender `View` (the box underneath buttons) gets its height as half of the height of a button and 1% of the controls padding (from controls styles).

Also, the rows are not absolutely positioned any more, they just use flex.

It works on Android, but I can't test on iOS currently, but should be fine.

Let me know if you want any clarification.